### PR TITLE
Validation deleteShouldReturnNotFoundWhenNonExistingId

### DIFF
--- a/src/test/java/com/devsuperior/bds02/controllers/CityControllerIT.java
+++ b/src/test/java/com/devsuperior/bds02/controllers/CityControllerIT.java
@@ -81,6 +81,7 @@ public class CityControllerIT {
 				mockMvc.perform(delete("/cities/{id}", nonExistingId));
 
 		result.andExpect(status().isNotFound());
+		result.andExpect(jsonPath("$.message").isNotEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
Rodando o teste apenas adicionando o endpoint /cities percebi que o teste deleteShouldReturnNotFoundWhenNonExistingId, adicionei uma validação na mensagem.